### PR TITLE
Fixed quorum size computation

### DIFF
--- a/src/bftsmart/reconfiguration/ServerViewController.java
+++ b/src/bftsmart/reconfiguration/ServerViewController.java
@@ -304,8 +304,8 @@ public class ServerViewController extends ViewController {
                 }
             }
 
-            this.quorumBFT = (int) Math.ceil((this.currentView.getN() + this.currentView.getF()) / 2);
-            this.quorumCFT = (int) Math.ceil(this.currentView.getN() / 2);
+            this.quorumBFT = (int) Math.ceil((this.currentView.getN() + this.currentView.getF()) / 2f);
+            this.quorumCFT = (int) Math.ceil(this.currentView.getN() / 2f);
         } else if (this.currentView != null && this.currentView.isMember(getStaticConf().getProcessId())) {
             //TODO: Left the system in newView -> LEAVE
             //CODE for LEAVE   


### PR DESCRIPTION
The division between two integers returns an integer (loss of precision) thus giving incorrect results for the quorum size.