### PR TITLE
Prevent leader replay attack

### DIFF
--- a/src/bftsmart/tom/core/TOMLayer.java
+++ b/src/bftsmart/tom/core/TOMLayer.java
@@ -465,7 +465,6 @@ public final class TOMLayer extends Thread implements RequestReceiver {
 					//notifies the client manager that this request was received and get
                     //the result of its validation
                     if (!clientsManager.requestReceived(requests[i], false)) {
-                        clientsManager.getClientsLock().unlock();
                         Logger.println("(TOMLayer.isProposedValueValid) finished, return=false");
                         System.out.println("failure in deserialize batch");
                         return null;


### PR DESCRIPTION
The leader can perform replay attack by proposing an old batch with
valid client signature and consensus ID.  The acceptors will treat it
as valid and re-execute the requests inside the batch.  The reply
received by clients would be error.

This patch prevent the replay attack by checking the last executed
sequence number of the replica and mark the leader proposed batch as
invalid if there exists any request that already be executed.

Fixes #40.