### PR TITLE
Stop deciding on values where proposal doesn't match accepted values

### DIFF
--- a/src/main/java/bftsmart/consensus/roles/Acceptor.java
+++ b/src/main/java/bftsmart/consensus/roles/Acceptor.java
@@ -413,7 +413,9 @@ public final class Acceptor {
 		logger.debug("I have {} ACCEPTs for cId:{}, Timestamp:{} ", epoch.countAccept(value), cid,
 				epoch.getTimestamp());
 
-		if (epoch.countAccept(value) > controller.getQuorum() && !epoch.getConsensus().isDecided()) {
+		if (epoch.countAccept(value) > controller.getQuorum()
+				&& !epoch.getConsensus().isDecided()
+				&& Arrays.equals(value, epoch.propValueHash)) {
 			logger.debug("Deciding consensus " + cid);
 			decide(epoch);
 		}


### PR DESCRIPTION
(During consensus:) Leader proposing one value for a subset of replicas, while making sure the remaining ones had matching data would lead to those wrongly informed replicas to internally decide on the wrong proposal, since it had only been checked if any proposal had been accepted, but not if it matches the proposal originally sent.