### PR TITLE
Sync equivoc patch

### DIFF
--- a/src/main/java/bftsmart/consensus/roles/Acceptor.java
+++ b/src/main/java/bftsmart/consensus/roles/Acceptor.java
@@ -413,7 +413,9 @@ public final class Acceptor {
 		logger.debug("I have {} ACCEPTs for cId:{}, Timestamp:{} ", epoch.countAccept(value), cid,
 				epoch.getTimestamp());
 
-		if (epoch.countAccept(value) > controller.getQuorum() && !epoch.getConsensus().isDecided()) {
+		if (epoch.countAccept(value) > controller.getQuorum()
+				&& !epoch.getConsensus().isDecided()
+				&& Arrays.equals(value, epoch.propValueHash)) {
 			logger.debug("Deciding consensus " + cid);
 			decide(epoch);
 		}

--- a/src/main/java/bftsmart/tom/core/DeliveryThread.java
+++ b/src/main/java/bftsmart/tom/core/DeliveryThread.java
@@ -284,13 +284,9 @@ public final class DeliveryThread extends Thread {
 
 						// cons.firstMessageProposed contains the performance counters
 						if (requests[count][0].equals(d.firstMessageProposed)) {
-							long time = requests[count][0].timestamp;
-							long seed = requests[count][0].seed;
-							int numOfNonces = requests[count][0].numOfNonces;
-							requests[count][0] = d.firstMessageProposed;
-							requests[count][0].timestamp = time;
-							requests[count][0].seed = seed;
-							requests[count][0].numOfNonces = numOfNonces;
+							d.firstMessageProposed.timestamp = requests[count][0].timestamp;
+							d.firstMessageProposed.seed = requests[count][0].seed;
+							d.firstMessageProposed.numOfNonces = requests[count][0].numOfNonces;
 						}
 
 						count++;


### PR DESCRIPTION
When synchronizing after leader change, the first proposed value will overwrite the actually decided-on value; this patch fixes that behavior.

Depends on #99.