### PR TITLE
Fix crash in AsyncLatencyClient with intervals <= 0

### DIFF
--- a/src/main/java/bftsmart/demo/microbenchmarks/AsyncLatencyClient.java
+++ b/src/main/java/bftsmart/demo/microbenchmarks/AsyncLatencyClient.java
@@ -223,7 +223,8 @@ public class AsyncLatencyClient {
                     if (i > (this.numberOfOps / 2)) st.store(System.nanoTime() - last_send_instant);
 
                     if (this.interval > 0 || this.rampup > 0) {
-                        Thread.sleep(Math.max(rand.nextInt(this.interval) + 1, this.rampup));
+                        int randomInterval = this.interval > 0 ? rand.nextInt(this.interval) : 0;
+                        Thread.sleep(Math.max(randomInterval + 1, this.rampup));
                         if (this.rampup > 0) this.rampup -= 100;
                     }
                     


### PR DESCRIPTION
A clear attempt was made in the AsyncLatencyClient to check for, and allow, an interval being smaller or equal to 0, but that check was incorrectly applied, leading to a crash of the client.