### PR TITLE
Fix jitpack.io publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ repositories {
 
 jar {
 	archivesBaseName='BFT-SMaRt'
-	project.version=""
 }
 
 ssh.settings {


### PR DESCRIPTION
To use this library as a maven dependency, it has to be published. jitpack.io automatically builds projects and serves them as maven publications. The latest builds failed [1] because a version field is empty.
This fixes the complaint [2].

Unfortunately, it breaks the `distTar` task with the following error message:
`Entry library-2.0/lib/BFT-SMaRt-2.0.jar is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/8.4/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details`.
We can either add `duplicatesStrategy = 'exclude'` to the distributions block or remove the `into('lib')` block completely.

[1] https://jitpack.io/com/github/bft-smart/library/-v1.2-g2bb506b-150/build.log
[2] https://jitpack.io/com/github/Mynacol/bft-smart/fix-jitpack-8e9696397c-1/build.log