### PR TITLE
Restore Java 8 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,11 @@ plugins {
 group 'BFT-SMaRt'
 version '2.0'
 
+java {
+	sourceCompatibility = JavaLanguageVersion.of(8)
+	targetCompatibility = JavaLanguageVersion.of(8)
+}
+
 repositories {
 	mavenCentral()
 }


### PR DESCRIPTION
Commit 687387f08150dcffa7d9ce3b57eaf2a0297d54f2 removed the clauses for Java 8 compatibility. This compiles the library to target whichever Java version is locally installed.

This commit re-introduces the Java 8 compatibility by using other non-deprecated property names.