### PR TITLE
Fix vulnerabilities and some minor issues

### DIFF
--- a/src/main/java/bftsmart/consensus/roles/Acceptor.java
+++ b/src/main/java/bftsmart/consensus/roles/Acceptor.java
@@ -54,11 +54,11 @@ public final class Acceptor {
 	private int me; // This replica ID
 	private ExecutionManager executionManager; // Execution manager of consensus's executions
 	private MessageFactory factory; // Factory for PaW messages
-	private ServerCommunicationSystem communication; // Replicas comunication system
+	private ServerCommunicationSystem communication; // Replicas communication system
 	private TOMLayer tomLayer; // TOM layer
 	private ServerViewController controller;
 
-	// thread pool used to paralelise creation of consensus proofs
+	// thread pool used to parallelize creation of consensus proofs
 	private ExecutorService proofExecutor = null;
 
 	/**
@@ -377,7 +377,6 @@ public final class Acceptor {
 
 	/**
 	 * Create a cryptographic proof for a consensus message
-	 * 
 	 * This method modifies the consensus message passed as an argument, so that it
 	 * contains a cryptographic proof.
 	 * 
@@ -407,7 +406,7 @@ public final class Acceptor {
 	 * Called when a ACCEPT message is received
 	 * 
 	 * @param epoch Epoch of the receives message
-	 * @param msg Consenus Message
+	 * @param msg Consensus Message
 	 */
 	private void acceptReceived(Epoch epoch, ConsensusMessage msg) {
 		int cid = epoch.getConsensus().getId();

--- a/src/main/java/bftsmart/consensus/roles/Acceptor.java
+++ b/src/main/java/bftsmart/consensus/roles/Acceptor.java
@@ -42,7 +42,7 @@ import bftsmart.tom.util.TOMUtil;
 
 /**
  * This class represents the acceptor role in the consensus protocol. This class
- * work together with the TOMLayer class in order to supply a atomic multicast
+ * work together with the TOMLayer class in order to supply an atomic multicast
  * service.
  *
  * @author Alysson Bessani
@@ -133,7 +133,7 @@ public final class Acceptor {
 	}
 
 	/**
-	 * Called when a Consensus message is received or when a out of context message
+	 * Called when a Consensus message is received or when an out of context message
 	 * must be processed. It processes the received message according to its type
 	 *
 	 * @param msg The message to be processed
@@ -310,7 +310,7 @@ public final class Acceptor {
 				logger.debug("Sending ACCEPT message, cId:{}, I am:{}", cid, me);
 
 				/**** LEADER CHANGE CODE! ******/
-				logger.debug("Setting consensus " + cid + " QuorumWrite tiemstamp to " + epoch.getConsensus().getEts()
+				logger.debug("Setting consensus " + cid + " QuorumWrite timestamp to " + epoch.getConsensus().getEts()
 						+ " and value " + Arrays.toString(value));
 				epoch.getConsensus().setQuorumWrites(value);
 				/*****************************************/
@@ -525,7 +525,7 @@ public final class Acceptor {
 			logger.debug(">>> >> >>  > Consensus " + cid  + " is already decided ");
 			Decision decision = epoch.getConsensus().getDecision();
 
-			// Dont forward a decision twice for the same requester in the same consensus instance
+			// Don't forward a decision twice for the same requester in the same consensus instance
 			if ( !executionManager.hasBeenForwardedAlready(msg.getEpoch(), msg.getSender())) {
 				logger.debug(">>> >> >> >> > Send FWD_DECISION for epoch " + epoch.getTimestamp() + " to replica " + msg.getSender());
 
@@ -542,7 +542,7 @@ public final class Acceptor {
 		} else {
 			boolean consensusIsDecidedButForgotten = msg.getNumber() <= tomLayer.getLastExec() - controller.getStaticConf().getCheckpointPeriod();
 			if (consensusIsDecidedButForgotten) {
-				// we will also arrive here if a replica forgets about past consensues, because the are removed from the consensuses map
+				// we will also arrive here if a replica forgets about past consensuses, because they are removed from the consensuses map
 				// this means the requester is left far behind and needs to perform a state transfer to catch up
 
 				logger.warn("decision request is too old to handle (decision has been garbage collected) and will be ignored");

--- a/src/main/java/bftsmart/consensus/roles/Acceptor.java
+++ b/src/main/java/bftsmart/consensus/roles/Acceptor.java
@@ -615,14 +615,15 @@ public final class Acceptor {
 			// For each ACCEPT message contained in the proof, check if the signature is correct
 			for (ConsensusMessage accept : proof) {
 
-				ConsensusMessage cm = new ConsensusMessage(accept.getType(), accept.getNumber(), accept.getEpoch(),
-						 accept.getSender(), accept.getValue());
+				ConsensusMessage cm = new ConsensusMessage(MessageFactory.ACCEPT, msg.getNumber(), msg.getEpoch(),
+						 accept.getSender(), decisionHash);
 
 				ByteArrayOutputStream bOut = new ByteArrayOutputStream(248);
 				try {
 					new ObjectOutputStream(bOut).writeObject(cm);
 				} catch (IOException ex) {
 					logger.error("ACCEPTOR.verifyDecision: Could not serialize message", ex);
+					continue;
 				}
 
 				byte[] data = bOut.toByteArray();
@@ -639,8 +640,7 @@ public final class Acceptor {
 				}
 
 				// The ACCEPT is valid and will be counted iff
-				if (Arrays.equals(accept.getValue(), decisionHash)    // decision hash equals digest in ACCEPT
-						&& validSignature 							  // ACCEPT's signature was successfully verified
+				if (validSignature 							  					      // ACCEPT's signature was successfully verified
 						&& !replicaID_already_counted.contains(accept.getSender())) { // unique: a replica may vote only once!
 
 					replicaID_already_counted.add(accept.getSender());

--- a/src/main/java/bftsmart/consensus/roles/Acceptor.java
+++ b/src/main/java/bftsmart/consensus/roles/Acceptor.java
@@ -38,7 +38,6 @@ import bftsmart.consensus.messages.MessageFactory;
 import bftsmart.reconfiguration.ServerViewController;
 import bftsmart.tom.core.ExecutionManager;
 import bftsmart.tom.core.TOMLayer;
-import bftsmart.tom.core.messages.TOMMessage;
 import bftsmart.tom.util.TOMUtil;
 
 /**
@@ -345,7 +344,7 @@ public final class Acceptor {
 						// Create a cryptographic proof for this ACCEPT message
 						logger.debug(
 								"Creating cryptographic proof for the correct ACCEPT message from consensus " + cid);
-						insertProof(correctAccept, epoch.deserializedPropValue);
+						insertProof(correctAccept);
 
 						communication.getServersConn().send(targets, correctAccept, true);
 
@@ -368,7 +367,7 @@ public final class Acceptor {
 
 				// Create a cryptographic proof for this ACCEPT message
 				logger.debug("Creating cryptographic proof for speculative ACCEPT message from consensus " + cid);
-				insertProof(cm, epoch.deserializedPropValue);
+				insertProof(cm);
 
 				epoch.setAcceptMsg(cm);
 
@@ -383,9 +382,8 @@ public final class Acceptor {
 	 * contains a cryptographic proof.
 	 * 
 	 * @param cm   The consensus message to which the proof shall be set
-	 * @param msgs tom messages
-	 */
-	private void insertProof(ConsensusMessage cm, TOMMessage[] msgs) {
+     */
+	private void insertProof(ConsensusMessage cm) {
 		ByteArrayOutputStream bOut = new ByteArrayOutputStream(248);
 		try {
 			ObjectOutputStream obj = new ObjectOutputStream(bOut);

--- a/src/main/java/bftsmart/tom/core/Synchronizer.java
+++ b/src/main/java/bftsmart/tom/core/Synchronizer.java
@@ -75,7 +75,7 @@ public class Synchronizer {
     private final Acceptor acceptor;
     private final MessageDigest md;
             
-    // Attributes to temporarely store synchronization info
+    // Attributes to temporarily store synchronization info
     // if state transfer is required for synchronization
     private int tempRegency = -1;
     private CertifiedDecision tempLastHighestCID = null;
@@ -99,7 +99,7 @@ public class Synchronizer {
         this.md = this.tom.md;
         
         this.outOfContextLC = new HashSet<>();
-	this.lcManager = new LCManager(this.tom,this.controller, this.md);
+	    this.lcManager = new LCManager(this.tom,this.controller, this.md);
     }
 
     public LCManager getLCManager() {
@@ -345,7 +345,7 @@ public class Synchronizer {
     }
 
     // Deserializes requests that were included in STOP messages
-    private TOMMessage[] deserializeTOMMessages(byte[] playload) {
+    private TOMMessage[] deserializeTOMMessages(byte[] payload) {
 
         ByteArrayInputStream bis;
         ObjectInputStream ois;
@@ -354,7 +354,7 @@ public class Synchronizer {
 
         try { // deserialize the content of the STOP message
 
-            bis = new ByteArrayInputStream(playload);
+            bis = new ByteArrayInputStream(payload);
             ois = new ObjectInputStream(bis);
 
             boolean hasReqs = ois.readBoolean();
@@ -441,7 +441,7 @@ public class Synchronizer {
         }
 
     }
-    // this method is called when a timeout occurs or when a STOP message is recevied
+    // this method is called when a timeout occurs or when a STOP message is received
     private void startSynchronization(int nextReg) {
 
         boolean condition;
@@ -457,7 +457,7 @@ public class Synchronizer {
         // Ask to start the synchronizations phase if enough messages have been received already
         if (condition && lcManager.getNextReg() == lcManager.getLastReg()) {
             
-            logger.debug("Initialize synch phase");
+            logger.debug("Initialize sync phase");
             requestsTimer.Enabled(false);
             requestsTimer.stopTimer();
 
@@ -475,7 +475,7 @@ public class Synchronizer {
             addSTOPedRequestsToClientManager();
             List<TOMMessage> messages = getRequestsToRelay();
 
-            try { // serialize conent to send in the STOP message
+            try { // serialize content to send in the STOP message
                 bos = new ByteArrayOutputStream();
                 out = new ObjectOutputStream(bos);
 
@@ -878,7 +878,7 @@ public class Synchronizer {
                 boolean isExpectedSync = (regency == lcManager.getLastReg() && regency == lcManager.getNextReg());
 
                 // Is this sync what I wanted to get in the previous iteration of the synchoronization phase?
-                boolean islateSync = (regency == lcManager.getLastReg() && regency == (lcManager.getNextReg() - 1));
+                boolean isLateSync = (regency == lcManager.getLastReg() && regency == (lcManager.getNextReg() - 1));
 
                 //Did I already sent a stopdata in this iteration?
                 boolean sentStopdata = (lcManager.getStopsSize(lcManager.getNextReg()) == 0); //if 0, I already purged the stops,
@@ -887,7 +887,7 @@ public class Synchronizer {
 
                 // I am (or was) waiting for this message, and did I received it from the new leader?
                 if ((isExpectedSync || // Expected case
-                        (islateSync && !sentStopdata)) && // might happen if I timeout before receiving the SYNC
+                        (isLateSync && !sentStopdata)) && // might happen if I timeout before receiving the SYNC
                         (msg.getSender() == execManager.getCurrentLeader())) {
 
                 //if (msg.getReg() == lcManager.getLastReg() &&

--- a/src/main/java/bftsmart/tom/core/Synchronizer.java
+++ b/src/main/java/bftsmart/tom/core/Synchronizer.java
@@ -555,43 +555,43 @@ public class Synchronizer {
 
                     //Do I have info on my last executed consensus?
                     if (cons != null && cons.getDecisionEpoch() != null && cons.getDecisionEpoch().propValue != null) {
+                            
+                        out.writeBoolean(true);
+                        out.writeInt(last);
+                        //byte[] decision = exec.getLearner().getDecision();
+
+                        byte[] decision = cons.getDecisionEpoch().propValue;
+                        Set<ConsensusMessage> proof = cons.getDecisionEpoch().getProof();
+
+                        out.writeObject(decision);
+                        out.writeObject(proof);
+                        // TODO: WILL BE NECESSARY TO ADD A PROOF!!!
+
+                    } else {
+                        out.writeBoolean(false);
                         
-                    out.writeBoolean(true);
-                    out.writeInt(last);
-                    //byte[] decision = exec.getLearner().getDecision();
+                        ////// THIS IS TO CATCH A BUG!!!!!
+                        if (last > -1) {
+                            logger.debug("[DEBUG INFO FOR LAST CID #1]");
 
-                    byte[] decision = cons.getDecisionEpoch().propValue;
-                    Set<ConsensusMessage> proof = cons.getDecisionEpoch().getProof();
+                            if (cons == null) {
+                                if (last > -1) logger.debug("No consensus instance for cid " + last);
 
-                    out.writeObject(decision);
-                    out.writeObject(proof);
-                    // TODO: WILL BE NECESSARY TO ADD A PROOF!!!
-
-                } else {
-                    out.writeBoolean(false);
-                    
-                    ////// THIS IS TO CATCH A BUG!!!!!
-                    if (last > -1) {
-                        logger.debug("[DEBUG INFO FOR LAST CID #1]");
-
-                        if (cons == null) {
-                            if (last > -1) logger.debug("No consensus instance for cid " + last);
-
-                        }
-                        else if (cons.getDecisionEpoch() == null) {
-                            logger.debug("No decision epoch for cid " + last);
-                        } else {
-                            logger.debug("epoch for cid: " + last + ": " + cons.getDecisionEpoch().toString());
-
-                            if (cons.getDecisionEpoch().propValue == null) {
-                                logger.debug("No propose for cid " + last);
+                            }
+                            else if (cons.getDecisionEpoch() == null) {
+                                logger.debug("No decision epoch for cid " + last);
                             } else {
-                                logger.debug("Propose hash for cid " + last + ": " + Base64.encodeBase64String(tom.computeHash(cons.getDecisionEpoch().propValue)));
+                                logger.debug("epoch for cid: " + last + ": " + cons.getDecisionEpoch().toString());
+
+                                if (cons.getDecisionEpoch().propValue == null) {
+                                    logger.debug("No propose for cid " + last);
+                                } else {
+                                    logger.debug("Propose hash for cid " + last + ": " + Base64.encodeBase64String(tom.computeHash(cons.getDecisionEpoch().propValue)));
+                                }
                             }
                         }
-                    }
 
-                }
+                    }
 
                     if (in > -1) { // content of cid in execution
 

--- a/src/main/java/bftsmart/tom/core/Synchronizer.java
+++ b/src/main/java/bftsmart/tom/core/Synchronizer.java
@@ -260,15 +260,19 @@ public class Synchronizer {
 
             lcManager.addCollect(regency, signedCollect);
 
-            int bizantineQuorum = (controller.getCurrentViewN() + controller.getCurrentViewF()) / 2;
+            int byzantineQuorum = (controller.getCurrentViewN() + controller.getCurrentViewF()) / 2;
             int cftQuorum = (controller.getCurrentViewN()) / 2;
 
             // Did I already got messages from a Byzantine/Crash quorum,
             // related to the last cid as well as for the current?
-            boolean conditionBFT = (controller.getStaticConf().isBFT() && lcManager.getLastCIDsSize(regency) > bizantineQuorum
-                    && lcManager.getCollectsSize(regency) > bizantineQuorum);
+            boolean conditionBFT = (lcManager.getLastCIDsSize(regency) > byzantineQuorum
+                    && lcManager.getCollectsSize(regency) > byzantineQuorum
+            );
 
-            boolean conditionCFT = (lcManager.getLastCIDsSize(regency) > cftQuorum && lcManager.getCollectsSize(regency) > cftQuorum);
+            boolean conditionCFT = (!controller.getStaticConf().isBFT()
+                    && lcManager.getLastCIDsSize(regency) > cftQuorum
+                    && lcManager.getCollectsSize(regency) > cftQuorum
+            );
 
             if (conditionBFT || conditionCFT) {
                 catch_up(regency);

--- a/src/main/java/bftsmart/tom/leaderchange/LCManager.java
+++ b/src/main/java/bftsmart/tom/leaderchange/LCManager.java
@@ -707,6 +707,10 @@ public class LCManager {
     private HashSet<CollectData> getSignedCollects(HashSet<SignedObject> signedCollects) {
 
         HashSet<CollectData> colls = new HashSet<CollectData>();
+        HashSet<Integer> currentViewMembers = new HashSet<>();
+        for (int processId : SVController.getCurrentViewAcceptors()) {
+            currentViewMembers.add(processId);
+        }
 
         for (SignedObject so : signedCollects) {
 
@@ -714,7 +718,7 @@ public class LCManager {
             try {
                 c = (CollectData) so.getObject();
                 int sender = c.getPid();
-                if (tomLayer.verifySignature(so, sender)) {
+                if (currentViewMembers.contains(sender) && tomLayer.verifySignature(so, sender)) {
                     colls.add(c);
                 }
             } catch (IOException | ClassNotFoundException ex) {
@@ -737,7 +741,9 @@ public class LCManager {
         for (CollectData c : collects) {
 
             if (c.getCid() == cid) {
-                result.add(c);
+                if (c.getEts() == regency) {
+                    result.add(c);
+                }
             }
             else {
                 result.add(new CollectData(c.getPid(), cid, regency, new TimestampValuePair(0, new byte[0]), new HashSet<TimestampValuePair>()));

--- a/src/main/java/bftsmart/tom/leaderchange/LCManager.java
+++ b/src/main/java/bftsmart/tom/leaderchange/LCManager.java
@@ -76,7 +76,8 @@ public class LCManager {
     /**
      * Constructor
      *
-     * @param reconfManager The reconfiguration manager from TOM layer
+     * @param tomLayer The TOM layer
+     * @param SVController The reconfiguration manager from TOM layer
      * @param md The message digest engine from TOM layer
      */
     public LCManager(TOMLayer tomLayer,ServerViewController SVController, MessageDigest md) {
@@ -203,7 +204,7 @@ public class LCManager {
 
     /**
      * Set the next regency
-     * @param nextts next regency
+     * @param nextreg next regency
      */
     public void setNextReg(int nextreg) {
         this.nextreg = nextreg;
@@ -231,7 +232,7 @@ public class LCManager {
 
     /**
      * Discard information about STOP messages up to specified regency
-     * @param ts timestamp up to which to discard messages
+     * @param regency timestamp up to which to discard messages
      */
     public void removeStops(int regency) {
         Integer[] keys = new Integer[stops.keySet().size()];
@@ -309,7 +310,7 @@ public class LCManager {
 
     /**
      * Keep collect from an incoming SYNC message
-     * @param ts the current regency
+     * @param regency the current regency
      * @param signedCollect the signed collect data
      */
     public void addCollect(int regency, SignedObject signedCollect) {


### PR DESCRIPTION
Vulnerabilities:

- The leader may collect SignedCollect from ancient regencies in SYNC message, replacing the real SignedCollect messages in STOPDATAs. Once there is one conditional collect ending with unbound condition, the leader can use those SignedCollect messages to create an unbound condition at any future epoch. 
- The leader may collect SignedCollect from nodes not in current view.
- verifyDecision does not check whether ACCEPT messages are for the same consensus and epoch. Byzantine node can gather ACCEPT messages in different consensus to trick honest node into wrongly executing a request.

Minor issues:

- Typos
- Indent
- Inconsistent Javadocs
- Useless parameter of insertProof in Acceptor
- In BFT mode, catchup is entered many times with the condition of CFT