### PR TITLE
Fix mutation of otherProcesses when filtering replica targets

### DIFF
--- a/src/main/java/bftsmart/reconfiguration/ServerViewController.java
+++ b/src/main/java/bftsmart/reconfiguration/ServerViewController.java
@@ -102,11 +102,15 @@ public class ServerViewController extends ViewController {
                 break;
             }
         }
-        if (index != -1) {
-            System.arraycopy(replicas, index + 1, replicas, index, replicas.length - index - 1);
-            replicas = Arrays.copyOfRange(replicas, 0, replicas.length - 1);
+
+        if (index == -1) {
+            return Arrays.copyOf(replicas, replicas.length);
         }
-        return replicas;
+
+        int[] copy = new int[replicas.length - 1];
+        System.arraycopy(replicas, 0, copy, 0, index);
+        System.arraycopy(replicas, index + 1, copy, index, replicas.length - index - 1);
+        return copy;
     }
 
     public int[] getCurrentViewAcceptors() {


### PR DESCRIPTION
- `ServerViewController.getReplicasWithout` was mutating the input array (e.g., `ServerViewController.otherProcesses`), corrupting the view data when used by decision-forwarding.
- Now it returns a new array with the target `without` replica removed, leaving the original array unchanged.